### PR TITLE
Default API and MongoDB endpoints to localhost

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,10 +15,9 @@ export default defineConfig(({ command, mode }) => {
     server: {
       proxy: {
         '/api': {
-          target: env["API_SERVER_ENDPOINT"],
+          target: env["API_SERVER_ENDPOINT"] ?? "http://localhost:5000/",
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/api/, '')
-
         }
       }
     }

--- a/services/configurations.py
+++ b/services/configurations.py
@@ -34,10 +34,3 @@ services = [{"ip": vm_ip, "port": 8000, "name": "saarbahn"},
             {"ip": vm_ip, "port": 5445, "name": "saarsecvv"},
             {"ip": vm_ip, "port": 8080, "name": "saarcloud"},
             {"ip": vm_ip, "port": 11025, "name": "saarloop"}]
-
-
-def containsFlag(text):
-    # todo implementare logica contains
-    regex_flag = os.getenv("REACT_APP_FLAG_REGEX", r'[A-Z0-9]{31}=')
-    match = re.match(regex_flag, text)
-    return match

--- a/services/configurations.py
+++ b/services/configurations.py
@@ -25,7 +25,7 @@
 import re
 import os
 
-mongo_host = os.getenv("TULIP_MONGO", "0.0.0.0:27017")
+mongo_host = os.getenv("TULIP_MONGO", "localhost:27017")
 mongo_server = f'mongodb://{mongo_host}/'
 vm_ip = "192.168.201.2"  # todo put regex
 

--- a/services/go-importer/cmd/assembler/main.go
+++ b/services/go-importer/cmd/assembler/main.go
@@ -63,7 +63,7 @@ func main() {
 		*mongodb = os.Getenv("TULIP_MONGO")
 		// if that didn't work, just guess a reasonable default
 		if *mongodb == "" {
-			*mongodb = "mongo:27017"
+			*mongodb = "localhost:27017"
 		}
 	}
 

--- a/services/go-importer/cmd/enricher/main.go
+++ b/services/go-importer/cmd/enricher/main.go
@@ -33,7 +33,7 @@ func main() {
 		*mongodb = os.Getenv("TULIP_MONGO")
 		// if that didn't work, just guess a reasonable default
 		if *mongodb == "" {
-			*mongodb = "mongo:27017"
+			*mongodb = "localhost:27017"
 		}
 	}
 


### PR DESCRIPTION
First of all, thank you for sharing this awesome code!

This pull request proposes to default all API and MongoDB endpoints to `localhost` when the respective environment variable is absent. This seems to be a sanier default than hardcoding containers hostname in the code.
It also renames `REACT_APP_FLAG_REGEX` to `FLAG_REGEX`, which might have been a bug.

Best regards,