### PR TITLE
Fixes #19 (command injection in data2req templating)

### DIFF
--- a/services/data2req.py
+++ b/services/data2req.py
@@ -98,6 +98,9 @@ def decode_http_request(raw_request, tokenize):
 def convert_single_http_requests(raw_request, flow, tokenize=True, use_requests_session=False):
     
     request, data, data_param_name, headers = decode_http_request(raw_request, tokenize)
+    request_method = validate_request_method(request.command)
+    request_path = escape_request_path(request.path)
+
     rtemplate = Environment(loader=BaseLoader()).from_string("""import os
 import requests
 import sys
@@ -112,12 +115,13 @@ headers = {{headers}}
 {% endif %}
 data = {{data}}
 
-{% if use_requests_session %}s{% else %}requests{% endif %}.{{request.command.lower()}}("http://{}:{{port}}{{request.path}}".format(host), {{data_param_name}}=data{% if not use_requests_session %}, headers=headers{% endif %})""")
+{% if use_requests_session %}s{% else %}requests{% endif %}.{{request_method}}(f"http://{{ '{' }}host{{ '}' }}:{{port}}{{request_path}}", {{data_param_name}}=data{% if not use_requests_session %}, headers=headers{% endif %})""")
 
     return rtemplate.render(
             headers=str(dict(headers)),
             data=data,
-            request=request,
+            request_method=request_method,
+            request_path=request_path,
             data_param_name=data_param_name,
             use_requests_session=use_requests_session,
             port=flow["dst_port"]
@@ -141,6 +145,9 @@ s = requests.Session()
     for message in flow['flow']:
         if message['from'] == 'c':
             request, data, data_param_name, headers = decode_http_request(message['data'].encode(), tokenize)
+            request_method = validate_request_method(request.command)
+            request_path = escape_request_path(request.path)
+            
             script += render("""
 {% if use_requests_session %}
 s.headers = {{headers}}
@@ -148,10 +155,27 @@ s.headers = {{headers}}
 headers = {{headers}}
 {% endif %}
 data = {{data}}
-{% if use_requests_session %}s{% else %}requests{% endif %}.{{request.command.lower()}}("http://{}:{{port}}{{request.path}}".format(host), {{data_param_name}}=data{% if not use_requests_session %}, headers=headers{% endif %})""", headers=str(dict(headers)),
+{% if use_requests_session %}s{% else %}requests{% endif %}.{{request_method}}(f"http://{{ '{' }}host{{ '}' }}:{{port}}{{request_path}}", {{data_param_name}}=data{% if not use_requests_session %}, headers=headers{% endif %})""",
+            headers=str(dict(headers)),
             data=data,
-            request=request,
+            request_method=request_method,
+            request_path=request_path,
             data_param_name=data_param_name,
             use_requests_session=use_requests_session,
             port=port)
     return script
+
+def validate_request_method(request_method: str):
+    request_method = request_method.lower()
+    if request_method not in ['delete', 'get', 'head', 'options', 'patch', 'post', 'put']:
+        # Throw Exception for a bad method to prevent command inject via a nasty request method
+        raise Exception(f'Invalid request method: {request_method}')
+    return request_method
+
+def escape_request_path(path: str):
+    """Escape backslashes and either quote character with an additional backslash. Also escape curly braces with an additional curly brace"""
+    # Prevent command injection via a nasty request path by escaping characters
+    replacements = (('\\', '\\\\'), ("'", "\\'"), ('"', '\\"'), ('{', '{{'), ('}', '}}'))
+    for old, new in replacements:
+        path = path.replace(old, new)
+    return path


### PR DESCRIPTION
# Notes
- Added `validate_request_method` to make sure the the request method is "get", "post", "patch" etc so that the call `requests.{request_method}` is actually a valid function
- Added `escape_request_path` to escape the following chars in the request path `'`, `"`, `{`, `}`, `\`. 
  - Escaping quotes and backslashes is needed so the request_path can't be injected by terminating the string early
  - Escaping curly brackets is needed as we are using a format string and don't want to inject any parameters https://stackoverflow.com/a/5466478
- Replaced `.format(host)` with an f-string (been around since python 3.6 and is more readable IMO)

Fixes #19 

# Test cases
## Example 1 - bad path (command injection)
Any backslash or quote characters in the path are escaped by an additional backslash
### Request
```python
req = (
    f'GET /"+__import__("os").system("whoami")+"/path HTTP/1.1\n'
    f'Host: 192.168.1.107:1337\n'
    f'\n'
)

# RAW
"""
GET /"+__import__("os").system("whoami")+"/path HTTP/1.1
Host: 192.168.1.107:1337

"""
```

### Tulip output (PythonRequest View)
```python
...
requests.get(f"http://{host}:1337/\"+__import__(\"os\").system(\"whoami\")+\"/path", data=data, headers=headers)
```

### Tulip output (Copy as Requests)
```python
...
s.get(f"http://{host}:1337/\"+__import__(\"os\").system(\"whoami\")+\"/path", data=data)
```

## Example 2 - bad path
Just tried spamming bad characters to make sure the escaping worked. Note the curly braces in the path get doubled.
### Request
```python
req = (
    f'''GET /+\\"'\\\\""'\\'"'\\'"\\"{{}}{{1}}{{-1}}{{name}}''\\\\\\'"'\\\\\\"\\' HTTP/1.1\n'''
    f'Host: 192.168.1.107:1337\n'
    f'\n'
)

# RAW
"""
GET /+\"'\\""'\'"'\'"\"{}{1}{-1}{name}''\\\'"'\\\"\' HTTP/1.1
Host: 192.168.1.107:1337

"""
```

### Tulip output (PythonRequest View)
```python
...
requests.get(f"http://{host}:1337/+\\\"\'\\\\\"\"\'\\\'\"\'\\\'\"\\\"{{}}{{1}}{{-1}}{{name}}\'\'\\\\\\\'\"\'\\\\\\\"\\\'", data=data, headers=headers)
```

### Tulip output (Copy as Requests)
```python
...
s.get(f"http://{host}:1337/+\\\"\'\\\\\"\"\'\\\'\"\'\\\'\"\\\"{{}}{{1}}{{-1}}{{name}}\'\'\\\\\\\'\"\'\\\\\\\"\\\'", data=data)
```

## Example 3 - bad request method
Here there was no point generating a python3 requests script as the request method used didn't conform to the usual "GET"/"POST"/"PATCH" etc. I opted to raise an Exception here, but could potentially just call `requests.unknown` instead if throwing was undesirable?

### Request
```python
req = (
    f'get(__import__("os").system("whoami"))# /path HTTP/1.1\n'
    f'Host: 192.168.1.107:1337\n'
    f'\n'
)

# RAW
"""
get(__import__("os").system("whoami"))# /path HTTP/1.1
Host: 192.168.1.107:1337

"""
```

### Tulip output (both PythonRequest View and Copy as Requests)
```
There was an error while converting the request:
Exception: Invalid request method: get(__import__("os").system("whoami"))#
```
