### PR TITLE
Add PCAP-over-ip and BPF Support to assembler

### DIFF
--- a/services/go-importer/cmd/assembler/main.go
+++ b/services/go-importer/cmd/assembler/main.go
@@ -39,11 +39,10 @@ var pcap_over_ip = flag.String("pcap-over-ip", "", "PCAP-over-IP host + port (e.
 var bpf = flag.String("bpf", "", "BPF filter")
 var nonstrict = flag.Bool("nonstrict", false, "Do not check strict TCP / FSM flags")
 var experimental = flag.Bool("experimental", false, "Enable experimental features.")
-var flushAfter = flag.String("flush-after", "", `
-Connections which have buffered packets (they've gotten packets out of order and
+var flushAfter = flag.String("flush-after", "", `Connections which have buffered packets (they've gotten packets out of order and
 are waiting for old packets to fill the gaps) can be flushed after they're this old
 (their oldest gap is skipped). This is particularly useful for pcap-over-ip captures.
-Any string parsed by time. ParseDuration is acceptable here. No flushing is done if
+Any string parsed by time.ParseDuration is acceptable here (ie. "3m", "2h45m"). No flushing is done if
 kept empty.`)
 
 var g_db db.Database

--- a/services/go-importer/cmd/assembler/main.go
+++ b/services/go-importer/cmd/assembler/main.go
@@ -265,8 +265,9 @@ func processPcapHandle(handle *pcap.Handle, fname string) {
 
 	var nextFlush time.Time
 	var flushDuration time.Duration
+	var err error
 	if *flushAfter != "" {
-		flushDuration, err := time.ParseDuration(*flushAfter)
+		flushDuration, err = time.ParseDuration(*flushAfter)
 		if err != nil {
 			log.Fatal("invalid flush duration: ", *flushAfter)
 		}
@@ -286,9 +287,9 @@ func processPcapHandle(handle *pcap.Handle, fname string) {
 		if !nextFlush.IsZero() {
 			// Check to see if we should flush the streams we have that haven't seen any new data in a while.
 			// Note that pcapOpenOfflineFile is blocking so we need at least see some packets passing by to get here.
-			if time.Now().After(nextFlush) {
+			if time.Since(nextFlush) > 0 {
 				log.Printf("flushing all streams that haven't seen packets in the last %s", *flushAfter)
-				assembler.FlushCloseOlderThan(time.Now().Add(flushDuration))
+				assembler.FlushCloseOlderThan(time.Now().Add(-flushDuration))
 				nextFlush = time.Now().Add(flushDuration / 2)
 			}
 		}

--- a/services/go-importer/cmd/assembler/main.go
+++ b/services/go-importer/cmd/assembler/main.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"go-importer/internal/pkg/db"
+	"net"
 
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -34,8 +35,16 @@ var promisc = true
 var watch_dir = flag.String("dir", "", "Directory to watch for new pcaps")
 var mongodb = flag.String("mongo", "", "MongoDB dns name + port (e.g. mongo:27017)")
 var flag_regex = flag.String("flag", "", "flag regex, used for flag in/out tagging")
+var pcap_over_ip = flag.String("pcap-over-ip", "", "PCAP-over-IP host + port (e.g. remote:1337)")
+var bpf = flag.String("bpf", "", "BPF filter")
 var nonstrict = flag.Bool("nonstrict", false, "Do not check strict TCP / FSM flags")
 var experimental = flag.Bool("experimental", false, "Enable experimental features.")
+var flushAfter = flag.String("flush-after", "", `
+Connections which have buffered packets (they've gotten packets out of order and
+are waiting for old packets to fill the gaps) can be flushed after they're this old
+(their oldest gap is skipped). This is particularly useful for pcap-over-ip captures.
+Any string parsed by time. ParseDuration is acceptable here. No flushing is done if
+kept empty.`)
 
 var g_db db.Database
 
@@ -77,17 +86,49 @@ func main() {
 		}
 	}
 
+	if *pcap_over_ip == "" {
+		*pcap_over_ip = os.Getenv("PCAP_OVER_IP")
+	}
+
+	if *bpf == "" {
+		*bpf = os.Getenv("BPF")
+	}
+
 	db_string := "mongodb://" + *mongodb
+	log.Println("Connecting to MongoDB:", db_string, "...")
 	g_db = db.ConnectMongo(db_string)
+	log.Println("Connected, configuring MongoDB database")
 	g_db.ConfigureDatabase()
 
-	// Pass positional arguments to the pcap handler
-	handlePcaps(flag.Args())
+	if *pcap_over_ip != "" {
+		log.Println("Connecting to PCAP-over-IP:", *pcap_over_ip)
+		tcpServer, err := net.ResolveTCPAddr("tcp", *pcap_over_ip)
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	// If a watch dir was configured, handle all files in the directory, then
-	// keep monitoring it for new files.
-	if *watch_dir != "" {
-		watchDir(*watch_dir)
+		conn, err := net.DialTCP("tcp", nil, tcpServer)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer conn.Close()
+		pcapFile, err := conn.File()
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer pcapFile.Close()
+		handlePcapFile(pcapFile, *pcap_over_ip, *bpf)
+	} else {
+		// Pass positional arguments to the pcap handler
+		for _, uri := range flag.Args() {
+			handlePcapUri(uri, *bpf)
+		}
+
+		// If a watch dir was configured, handle all files in the directory, then
+		// keep monitoring it for new files.
+		if *watch_dir != "" {
+			watchDir(*watch_dir)
+		}
 	}
 }
 
@@ -110,8 +151,8 @@ func watchDir(watch_dir string) {
 	}
 
 	for _, file := range files {
-		if strings.HasSuffix(file.Name(), ".pcap") {
-			handlePcap(filepath.Join(watch_dir, file.Name())) //FIXME; this is a little clunky
+		if strings.HasSuffix(file.Name(), ".pcap") || strings.HasSuffix(file.Name(), ".pcapng") {
+			handlePcapUri(filepath.Join(watch_dir, file.Name()), *bpf) //FIXME; this is a little clunky
 		}
 	}
 
@@ -133,10 +174,10 @@ func watchDir(watch_dir string) {
 					return
 				}
 				if event.Op&(fsnotify.Rename|fsnotify.Create) != 0 {
-					if strings.HasSuffix(event.Name, ".pcap") {
+					if strings.HasSuffix(event.Name, ".pcap") || strings.HasSuffix(event.Name, ".pcapng") {
 						log.Println("Found new file", event.Name, event.Op.String())
 						time.Sleep(2 * time.Second) // FIXME; bit of race here between file creation and writes.
-						handlePcap(event.Name)
+						handlePcapUri(event.Name, *bpf)
 					}
 				}
 			case err, ok := <-watcher.Errors:
@@ -157,13 +198,7 @@ func watchDir(watch_dir string) {
 
 }
 
-func handlePcaps(file_list []string) {
-	for _, uri := range file_list {
-		handlePcap(uri)
-	}
-}
-
-func handlePcap(fname string) {
+func handlePcapUri(fname string, bpf string) {
 	var handle *pcap.Handle
 	var err error
 
@@ -178,6 +213,36 @@ func handlePcap(fname string) {
 		return
 	}
 
+	if bpf != "" {
+		if err := handle.SetBPFFilter(bpf); err != nil {
+			log.Println("Set BPF Filter error: ", err)
+			return
+		}
+	}
+
+	processPcapHandle(handle, fname)
+}
+
+func handlePcapFile(file *os.File, fname string, bpf string) {
+	var handle *pcap.Handle
+	var err error
+
+	if handle, err = pcap.OpenOfflineFile(file); err != nil {
+		log.Println("PCAP OpenOfflineFile error:", err)
+		return
+	}
+	defer handle.Close()
+
+	if bpf != "" {
+		if err := handle.SetBPFFilter(bpf); err != nil {
+			log.Println("Set BPF Filter error: ", err)
+			return
+		}
+	}
+	processPcapHandle(handle, fname)
+}
+
+func processPcapHandle(handle *pcap.Handle, fname string) {
 	var source *gopacket.PacketSource
 	nodefrag := false
 	linktype := handle.LinkType()
@@ -199,6 +264,17 @@ func handlePcap(fname string) {
 	streamPool := reassembly.NewStreamPool(streamFactory)
 	assembler := reassembly.NewAssembler(streamPool)
 
+	var nextFlush time.Time
+	var flushDuration time.Duration
+	if *flushAfter != "" {
+		flushDuration, err := time.ParseDuration(*flushAfter)
+		if err != nil {
+			log.Fatal("invalid flush duration: ", *flushAfter)
+		}
+		nextFlush = time.Now().Add(flushDuration / 2)
+		log.Println("Starting PCAP loop!")
+	}
+
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, os.Interrupt)
 
@@ -207,6 +283,16 @@ func handlePcap(fname string) {
 		data := packet.Data()
 		bytes += int64(len(data))
 		done := false
+
+		if !nextFlush.IsZero() {
+			// Check to see if we should flush the streams we have that haven't seen any new data in a while.
+			// Note that pcapOpenOfflineFile is blocking so we need at least see some packets passing by to get here.
+			if time.Now().After(nextFlush) {
+				log.Printf("flushing all streams that haven't seen packets in the last %s", *flushAfter)
+				assembler.FlushCloseOlderThan(time.Now().Add(flushDuration))
+				nextFlush = time.Now().Add(flushDuration / 2)
+			}
+		}
 
 		// defrag the IPv4 packet if required
 		// (TODO; IPv6 will not be defragged)


### PR DESCRIPTION
Thanks for open-sourcing this project. We have used Tulip during a CTF with a few patches of our own that we'd now like to contribute back into the original project.  

This pull requests adds (semi-realtime) streaming PCAP support to Tulip by utilizing PCAP-over-ip, as well as BPF support for both file-based and PCAP-over-ip based traffic ingestion.

We wanted lower-latency traffic streaming and opted for PCAP-over-ip.  As Tulip did not yet support this, we added PCAP-over-ip support. While we opted to combine this with [pcap-broker](https://github.com/fox-it/pcap-broker) to stream traffic from remote hosts, any pcap-over-ip server is supported.

This pull requests also adds support for adding a BPF filter, as we captured traffic once and distributed it to multiple listeners, for each of which we'd set the appropriate BPF. While we needed the BPF filter for PCAP-over-ip only, we also added it to the pcap file processing logic. 