### PR TITLE
Add option to frontend to exclude flows based on a tag

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -31,7 +31,8 @@ export const tulipApi = createApi({
         // Diederik gives you a beer once this has been fixed
         body: JSON.stringify({
           ...query,
-          tags: query.tags.length > 0 ? query.tags : undefined,
+          includeTags: query.includeTags.length > 0 ? query.includeTags : undefined,
+          excludeTags: query.excludeTags.length > 0 ? query.excludeTags : undefined,
         }),
       }),
     }),

--- a/frontend/src/components/Corrie.tsx
+++ b/frontend/src/components/Corrie.tsx
@@ -26,7 +26,8 @@ interface GraphProps {
 
 export const Corrie = () => {
   const { data: services } = useGetServicesQuery();
-  const filterTags = useAppSelector((state) => state.filter.filterTags);
+  const includeTags = useAppSelector((state) => state.filter.includeTags);
+  const excludeTags = useAppSelector((state) => state.filter.excludeTags);
 
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -47,7 +48,8 @@ export const Corrie = () => {
       from_time: from_filter,
       to_time: to_filter,
       service: "", // FIXME
-      tags: filterTags,
+      includeTags: includeTags,
+      excludeTags: excludeTags,
     },
     {
       refetchOnMountOrArgChange: true,

--- a/frontend/src/components/FlowList.tsx
+++ b/frontend/src/components/FlowList.tsx
@@ -39,7 +39,9 @@ export function FlowList() {
   const { data: availableTags } = useGetTagsQuery();
   const { data: services } = useGetServicesQuery();
 
-  const filterTags = useAppSelector((state) => state.filter.filterTags);
+  const includeTags = useAppSelector((state) => state.filter.includeTags);
+  const excludeTags = useAppSelector((state) => state.filter.excludeTags);
+
   const dispatch = useAppDispatch();
 
   const [starFlow] = useStarFlowMutation();
@@ -66,7 +68,8 @@ export function FlowList() {
       from_time: from_filter,
       to_time: to_filter,
       service: "", // FIXME
-      tags: filterTags,
+      includeTags: includeTags,
+      excludeTags: excludeTags
     },
     {
       refetchOnMountOrArgChange: true,
@@ -117,7 +120,8 @@ export function FlowList() {
                 <Tag
                   key={tag}
                   tag={tag}
-                  disabled={!filterTags.includes(tag)}
+                  disabled={!includeTags.includes(tag)}
+                  excluded={excludeTags.includes(tag)}
                   onClick={() => dispatch(toggleFilterTag(tag))}
                 ></Tag>
               ))}

--- a/frontend/src/components/Tag.tsx
+++ b/frontend/src/components/Tag.tsx
@@ -24,17 +24,23 @@ interface TagProps {
   tag: string;
   color?: string;
   disabled?: boolean;
+  excluded?: boolean;
   onClick?: () => void;
 }
-export const Tag = ({ tag, color, disabled = false, onClick }: TagProps) => {
-  const tagBackgroundColor = disabled ? "#eee" : color ?? tagToColor(tag);
+export const Tag = ({ tag, color, disabled = false, excluded = false, onClick }: TagProps) => {
+  var tagBackgroundColor = disabled ? "#eee" : color ?? tagToColor(tag);
 
-  const tagTextColor = disabled
+  var tagTextColor = disabled
     ? "#bbb"
     : Color(tagBackgroundColor).isDark()
-    ? "#fff"
-    : "#000";
+      ? "#fff"
+      : "#000";
 
+
+  if (excluded) {
+    tagTextColor = "white";
+    tagBackgroundColor = "black";
+  }
   return (
     <div
       onClick={onClick}
@@ -46,7 +52,7 @@ export const Tag = ({ tag, color, disabled = false, onClick }: TagProps) => {
         color: tagTextColor,
       }}
     >
-      <span>{tag}</span>
+      <span  style={excluded ? { textDecoration: 'line-through' } : {}}>{tag}</span>
     </div>
   );
 };

--- a/frontend/src/store/filter.ts
+++ b/frontend/src/store/filter.ts
@@ -1,7 +1,8 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 export interface TulipFilterState {
-  filterTags: string[];
+  includeTags: string[];
+  excludeTags: string[];
   // startTick?: number;
   // endTick?: number;
   // service?: string;
@@ -9,7 +10,8 @@ export interface TulipFilterState {
 }
 
 const initialState: TulipFilterState = {
-  filterTags: [],
+  includeTags: [],
+  excludeTags: [],
 };
 
 export const filterSlice = createSlice({
@@ -23,9 +25,28 @@ export const filterSlice = createSlice({
     //   state.endTick = action.payload;
     // },
     toggleFilterTag: (state, action: PayloadAction<string>) => {
-      state.filterTags = state.filterTags.includes(action.payload)
-        ? state.filterTags.filter((t) => t !== action.payload)
-        : [...state.filterTags, action.payload];
+      var included = state.includeTags.includes(action.payload)
+      var excluded = state.excludeTags.includes(action.payload)
+
+      // If a user clicks a 'included' tag, the tag should be 'excluded' instead.
+      if (included) {
+        // Remove from included
+        state.includeTags = state.includeTags.filter((t) => t !== action.payload);
+
+        // Add to excluded
+        state.excludeTags = [...state.excludeTags, action.payload]
+      } else {
+        // If the user clicks on an 'excluded' tag, the tag should be 'unset' from both include / exclude tags
+        if (excluded) {
+          // Remove from excluded
+          state.excludeTags = state.excludeTags.filter((t) => t !== action.payload);
+        } else {
+          if (!included && !excluded) {
+            // The tag was disabled, so it should be added to included now
+            state.includeTags = [...state.includeTags, action.payload]
+          }
+        }
+      }
     },
   },
 });

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -54,7 +54,8 @@ export interface FlowsQuery {
   dst_port?: number;
   from_time?: string;
   to_time?: string;
-  tags: string[];
+  includeTags: string[];
+  excludeTags: string[];
 }
 
 export type Service = {

--- a/services/db.py
+++ b/services/db.py
@@ -68,10 +68,15 @@ class DB:
         if "from_time" in filters and "to_time" in filters:
             f["time"] = {"$gte": int(filters["from_time"]),
                          "$lt": int(filters["to_time"])}
-        if "tags" in filters:
-            f["tags"] = {
-                "$all": [str(elem) for elem in filters["tags"]]
-            }
+        
+        tag_queries = {}
+        if "includeTags" in filters:
+            tag_queries["$all"] = [str(elem) for elem in filters["includeTags"]]
+        if "excludeTags" in filters:
+            tag_queries["$nin"] = [str(elem) for elem in filters["excludeTags"]]
+
+        if len(tag_queries.keys()) > 0:
+            f["tags"] = tag_queries
 
         print("query:")
         pprint.pprint(f)


### PR DESCRIPTION
Thanks for open-sourcing this project. We have used Tulip during a CTF with a few patches of our own that we'd now like to contribute back into the original project.

This pull request adds the option to 'exclude' traffic in the flowlist based on tags. In the intersection filter, users can click a tag once to alter it from a `disabled` to an `included` state (where traffic must have this tag to be listed in the flowlist), and again to alter it to an `excluded` state. For a tag in excluded state, a flow must not have this tag in order to be eligible for the flowlist.

This is especially useful in conjunction with pull request #25 that allows one to more easily tag traffic that might not be interesting. See the included screenshots for an example. Moreover, if you're using Suricata as an IPS, you can also exclude based on the 'Blocked' tag and ignore all the traffic that you're rejecting anyway. 

**Screenshots**
No tags included or excluded:
![flowlist_no_intersection](https://github.com/OpenAttackDefenseTools/tulip/assets/19346100/5577f63b-5c2d-4631-af0c-349164a965b5)
Including some tags while excluding others:
![flowlist_exclusion_and_inclusion_intersection](https://github.com/OpenAttackDefenseTools/tulip/assets/19346100/f7bc8746-2157-4145-acd9-e3ebea91f0bf)

