### PR TITLE
updated extension matching to accept .pcap*

### DIFF
--- a/services/go-importer/cmd/assembler/main.go
+++ b/services/go-importer/cmd/assembler/main.go
@@ -150,7 +150,8 @@ func watchDir(watch_dir string) {
 	}
 
 	for _, file := range files {
-		if strings.HasSuffix(file.Name(), ".pcap") || strings.HasSuffix(file.Name(), ".pcapng") {
+		// accepts files with prefixes that start with .pcap (.pcapng .pcap1 etc)
+		if strings.HasPrefix(filepath.Ext(file.Name()),".pcap") {
 			handlePcapUri(filepath.Join(watch_dir, file.Name()), *bpf) //FIXME; this is a little clunky
 		}
 	}
@@ -173,7 +174,8 @@ func watchDir(watch_dir string) {
 					return
 				}
 				if event.Op&(fsnotify.Rename|fsnotify.Create) != 0 {
-					if strings.HasSuffix(event.Name, ".pcap") || strings.HasSuffix(event.Name, ".pcapng") {
+					// accepts files with prefixes that start with .pcap (.pcapng .pcap1 etc)
+					if strings.HasPrefix(filepath.Ext(event.Name),".pcap") {
 						log.Println("Found new file", event.Name, event.Op.String())
 						time.Sleep(2 * time.Second) // FIXME; bit of race here between file creation and writes.
 						handlePcapUri(event.Name, *bpf)


### PR DESCRIPTION
If you run tcpdump with two constraints (eg every 30 seconds and max size 2mb) it will create files with the extension pcap1, pcap2 etc. 
[tcpdump man page](https://linux.die.net/man/8/tcpdump)
```
-rw-r--r--  1 root     root     226K Aug 26 12:07 wlan0-23-08-26_12.06.59.pcap
-rw-r--r--  1 root     root     2.0M Aug 26 12:07 wlan0-23-08-26_12.07.29.pcap
-rw-r--r--  1 root     root     2.0M Aug 26 12:07 wlan0-23-08-26_12.07.29.pcap1
-rw-r--r--  1 root     root     1.1M Aug 26 12:07 wlan0-23-08-26_12.07.29.pcap2
-rw-r--r--  1 root     root     2.0M Aug 26 12:08 wlan0-23-08-26_12.07.59.pcap
```
Tulip wont ingest these files as it only accepts .pcap and .pcapng. This change fixes that.
Now it will accept any file with an extension starting with pcap.