### PR TITLE
Use Gunicorn instead of the Flask development server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - internal
     volumes:
       - ${TRAFFIC_DIR_HOST}:${TRAFFIC_DIR_DOCKER}:ro
+    command: "gunicorn -w 3 -t 60 --log-level debug --capture-output --enable-stdio-inheritance -b 0.0.0.0:5000 webservice:application"
     environment:
       TULIP_MONGO: mongo:27017
       TULIP_TRAFFIC_DIR: ${TRAFFIC_DIR_DOCKER}

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -2,3 +2,4 @@ Flask_Cors
 pymongo
 Flask
 requests
+gunicorn

--- a/services/api/wsgi.py
+++ b/services/api/wsgi.py
@@ -1,0 +1,4 @@
+from webservice import application
+
+if __name__ == "__main__":
+    application.run(host='0.0.0.0', threaded=True)


### PR DESCRIPTION
I noticed the warning in the Docker logs:
```
WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
```
So I've made the Tulip API container use Gunicorn instead of the Flask development server