### PR TITLE
TCPDump container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ TICK_START="2018-06-27T13:00+02:00"
 # Tick length in ms
 TICK_LENGTH=180000
 
-#PCAP_OVER_IP="host.docker.internal:1337"
+#PCAP_OVER_IP="host.docker.internal:11337"
 #For multiple PCAP_OVER_IP you can comma separate
 #PCAP_OVER_IP="host.docker.internal:1337,otherhost.com:5050"
+
+# Set tcpdump command if you want to use tcpdump container
+# It will listen (PCAP-Over-IP) on the host on port 11337
+#TCPDUMP_CMD="tcpdump -i any -n -U --immediate-mode not port 22 and not port 11337 -s 65535 -w -"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,5 +79,14 @@ services:
     environment:
       TULIP_MONGO: ${TULIP_MONGO}
 
+  tcpdump:
+    build:
+      context: services/tcpdump
+      dockerfile: Dockerfile-tcpdump
+    image: tulip-tcpdump:latest
+    network_mode: "host"
+    environment:
+      TCPDUMP_CMD: ${TCPDUMP_CMD}
+
 networks:
   internal:

--- a/services/tcpdump/Dockerfile-tcpdump
+++ b/services/tcpdump/Dockerfile-tcpdump
@@ -1,0 +1,4 @@
+FROM alpine
+RUN apk add --update --no-cache bash tcpdump netcat-openbsd && rm -rf /var/cache/apk/*
+COPY entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]

--- a/services/tcpdump/entrypoint.sh
+++ b/services/tcpdump/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+if [ -z "$TCPDUMP_CMD" ]; then
+	echo "TCPDUMP_CMD not set in .env, exiting now assuming I'm not needed"
+	exit 1
+fi
+
+while true
+do
+	$TCPDUMP_CMD | nc -l 11337
+	echo "tcpdump command stopped, sleeping for 5s and restarting"
+	sleep 5
+done


### PR DESCRIPTION
I've added a tcpdump container that could be used to keep all the configuration required for Tulip in the same place. Of course for some CTFs this won't be useful in which case the container shuts down. The main scenario you would use this in is if you're running Tulip on the same server as the vulnbox.

It exposes the PCAP data using PCAP-Over-IP on port 11337 on the host. It exposes on the host network but there should be no risk once the assembler has connected. It should be possible to bind it to localhost only but idk how exactly to do that (I think using netcat on 127.0.0.1 in the container would bind to localhost within the container not the host?).

The tcpdump command can be modified from the env. The example command is probably imperfect maybe others can provide suggestions.