### PR TITLE
Remove redundant docker compose entries

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,6 @@ services:
     restart: unless-stopped
     ports:
       - "3000:3000"
-    expose:
-      - 3000
     depends_on:
       - timescale
       - api
@@ -36,7 +34,6 @@ services:
       - internal
     environment:
       API_SERVER_ENDPOINT: http://api:5000/
-      VIRTUAL_HOST: tulip.h4xx.eu
 
   api:
     build:


### PR DESCRIPTION
- Expose after ports is a no-op, and the frontend needs to be exposed to the host (therefore use ports)
- VIRTUAL_HOST seems to be an oversight from the last MR, there is no reference to it in the whole codebase