### PR TITLE
Fix wrong parsing of flags in ITAD flag validator

### DIFF
--- a/services/go-importer/cmd/assembler/flagValidator.go
+++ b/services/go-importer/cmd/assembler/flagValidator.go
@@ -111,11 +111,11 @@ func (validator *ItallyADFlagValidator) IsValid(flag string, refTime time.Time) 
 	if err != nil {
 		return false
 	}
-	team, err = strconv.ParseInt(flag[3:4], 36, 0) // = Team
+	team, err = strconv.ParseInt(flag[2:4], 36, 0) // = Team
 	if err != nil {
 		return false
 	}
-	service, err = strconv.ParseInt(flag[5:6], 36, 0) // = Service
+	service, err = strconv.ParseInt(flag[4:6], 36, 0) // = Service
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
Hi, this is a fix for the `itad` flag validator, as right now [it parses](https://github.com/OpenAttackDefenseTools/tulip/blob/523e5179043a5b6ae1bbcc1990d774f23166319b/services/go-importer/cmd/assembler/flagValidator.go#L110-L121) **2, 1, 1** bytes instead of **2, 2, 2** like described in both [ECSC 2024 Rules](https://ad.ecsc2024.it/rules) and [CyberChallenge.IT Rules](https://ad.cyberchallenge.it/rules):

> The following simple Python code can be used to decode flags:
> ```python
> flag = "080A02AF0J07UMOPHNE00KJ48KAE28C="
> round_number = int(flag[0:2], 36)
> team_number = int(flag[2:4], 36)
> service_number = int(flag[4:6], 36)
> ```

Thanks!
  
> [!NOTE]
>
> [ECSC 2025 flags](https://wiki.ad.ecsc2025.pl/game/#flags) apparently have a bit more information stored in them, but the first bytes are the same:
> 
> > Each flag consists of a prefix and suffix, that wrap a base64-encoded payload with the following format:
> > 
> > `2 bytes`: round id
> > `2 bytes`: team id
> > `2 bytes`: service id
> > `2 bytes`: flagstore id
> > `16 bytes`: SHA256-HMAC (of first 8 bytes)
